### PR TITLE
ensure transition will fire when using classes

### DIFF
--- a/src/Transition.ts
+++ b/src/Transition.ts
@@ -8,6 +8,7 @@ import {
   children,
   JSX
 } from "solid-js";
+import { nextFrame } from "./utils";
 
 type TransitionProps = {
   name?: string;
@@ -56,7 +57,7 @@ export const Transition: Component<TransitionProps> = props => {
       onBeforeEnter && onBeforeEnter(el);
       el.classList.add(...enterClasses);
       el.classList.add(...enterActiveClasses);
-      requestAnimationFrame(() => {
+      nextFrame(() => {
         el.classList.remove(...enterClasses);
         el.classList.add(...enterToClasses);
         onEnter && onEnter(el, endTransition);
@@ -90,7 +91,7 @@ export const Transition: Component<TransitionProps> = props => {
     onBeforeExit && onBeforeExit(prev);
     prev.classList.add(...exitClasses);
     prev.classList.add(...exitActiveClasses);
-    requestAnimationFrame(() => {
+    nextFrame(() => {
       prev.classList.remove(...exitClasses);
       prev.classList.add(...exitToClasses);
     });

--- a/src/TransitionGroup.ts
+++ b/src/TransitionGroup.ts
@@ -6,6 +6,7 @@ import {
   Component,
   children
 } from "solid-js";
+import { nextFrame } from "./utils";
 
 type BoundingRect = {
   top: number;
@@ -91,7 +92,7 @@ export const TransitionGroup: Component<TransitionGroupProps> = props => {
         onBeforeEnter && onBeforeEnter(el);
         el.classList.add(...enterClasses);
         el.classList.add(...enterActiveClasses);
-        requestAnimationFrame(() => {
+        nextFrame(() => {
           el.classList.remove(...enterClasses);
           el.classList.add(...enterToClasses);
           onEnter && onEnter(el, endTransition);
@@ -116,7 +117,7 @@ export const TransitionGroup: Component<TransitionGroupProps> = props => {
         onBeforeExit && onBeforeExit(old);
         old.classList.add(...exitClasses);
         old.classList.add(...exitActiveClasses);
-        requestAnimationFrame(() => {
+        nextFrame(() => {
           old.classList.remove(...exitClasses);
           old.classList.add(...exitToClasses);
         });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,5 @@
+export function nextFrame(fn: () => void) {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(fn);
+  });
+}


### PR DESCRIPTION
Hello,

I've noticed that sometimes on Firefox, although requesting a new frame, the enter- and enter-active- classes are instantly overwritten, thus not triggering the transition.

Vue's transition utility has a helper that calls requestAnimationFrame twice before firing a callback so I've tried to apply that method to your component and it fixed the issue.

Let me know what you think of it.

PS: Solid is a great library, keep up the good work !