### PR TITLE
fix: make sure endTransition is called without params by onEnter/onExit

### DIFF
--- a/src/Transition.ts
+++ b/src/Transition.ts
@@ -60,7 +60,7 @@ export const Transition: Component<TransitionProps> = props => {
       nextFrame(() => {
         el.classList.remove(...enterClasses);
         el.classList.add(...enterToClasses);
-        onEnter && onEnter(el, endTransition);
+        onEnter && onEnter(el, () => endTransition());
         if (!onEnter || onEnter.length < 2) {
           el.addEventListener("transitionend", endTransition);
           el.addEventListener("animationend", endTransition);
@@ -97,7 +97,7 @@ export const Transition: Component<TransitionProps> = props => {
       prev.classList.remove(...exitClasses);
       prev.classList.add(...exitToClasses);
     });
-    onExit && onExit(prev, endTransition);
+    onExit && onExit(prev, () => endTransition());
     if (!onExit || onExit.length < 2) {
       prev.addEventListener("transitionend", endTransition);
       prev.addEventListener("animationend", endTransition);

--- a/src/TransitionGroup.ts
+++ b/src/TransitionGroup.ts
@@ -95,7 +95,7 @@ export const TransitionGroup: Component<TransitionGroupProps> = props => {
         nextFrame(() => {
           el.classList.remove(...enterClasses);
           el.classList.add(...enterToClasses);
-          onEnter && onEnter(el, endTransition);
+          onEnter && onEnter(el, () => endTransition());
           if (!onEnter || onEnter.length < 2) {
             el.addEventListener("transitionend", endTransition);
             el.addEventListener("animationend", endTransition);
@@ -123,7 +123,7 @@ export const TransitionGroup: Component<TransitionGroupProps> = props => {
           old.classList.remove(...exitClasses);
           old.classList.add(...exitToClasses);
         });
-        onExit && onExit(old, endTransition);
+        onExit && onExit(old, () => endTransition());
         if (!onExit || onExit.length < 2) {
           old.addEventListener("transitionend", endTransition);
           old.addEventListener("animationend", endTransition);


### PR DESCRIPTION
onEnter/onExit are now called with () => endTransition() to ensure it isn't passed a parameter.